### PR TITLE
Add graph contraction filter for technical nodes

### DIFF
--- a/src/app/local/edit/page.tsx
+++ b/src/app/local/edit/page.tsx
@@ -199,7 +199,24 @@ function LocalEditorContent() {
 
     // Graph data - source nodes from backend API
     // Use nodes and edges (including backend-calculated default styles), while keeping legacyNodes for search and other compatibility features
-    const { nodes: astrolabeNodes, edges: astrolabeEdges, legacyNodes: graphNodes, links: graphLinks, loading: graphLoading, reload: reloadGraph, reloadMeta, projectStatus, needsInit, notSupported, recheckStatus } = useGraphData(projectPath)
+    const {
+        nodes: astrolabeNodes,
+        edges: astrolabeEdges,
+        legacyNodes: graphNodes,
+        links: graphLinks,
+        loading: graphLoading,
+        reload: reloadGraph,
+        reloadMeta,
+        projectStatus,
+        needsInit,
+        notSupported,
+        recheckStatus,
+        rawNodeCount,
+        rawEdgeCount,
+        filterOptions,
+        setFilterOptions,
+        filterStats,
+    } = useGraphData(projectPath)
 
     // Color helper - extract color mapping from backend-returned node data
     const typeColors = useMemo(() => {
@@ -1249,6 +1266,11 @@ function LocalEditorContent() {
                             <div className="absolute top-3 left-3 z-10 flex gap-2">
                                 <div className="bg-black/60 px-3 py-1.5 rounded text-xs text-white/60 font-mono">
                                     {canvasNodes.length} / {graphNodes.length} nodes
+                                    {filterOptions.hideTechnical && (filterStats.removedNodes > 0 || filterStats.orphanedNodes > 0) && (
+                                        <span className="text-yellow-400/60 ml-1" title={`${filterStats.removedNodes} technical, ${filterStats.orphanedNodes} orphaned`}>
+                                            ({filterStats.removedNodes + filterStats.orphanedNodes} hidden)
+                                        </span>
+                                    )}
                                 </div>
 
                                 {/* Refresh button */}
@@ -1318,18 +1340,23 @@ function LocalEditorContent() {
                                     </button>
                                 )}
 
-                                {/* Following buttons temporarily hidden, to be developed later */}
-                                {/* Filter button - TODO: backend to be developed
+                                {/* Hide Technical Nodes toggle */}
                                 <button
-                                    onClick={() => {
-                                        console.log('[Canvas] Filter clicked - TODO: implement filter panel')
-                                    }}
-                                    className="p-1.5 bg-black/60 hover:bg-white/20 rounded transition-colors"
-                                    title="Filter (TODO)"
+                                    onClick={() => setFilterOptions({
+                                        ...filterOptions,
+                                        hideTechnical: !filterOptions.hideTechnical
+                                    })}
+                                    className={`p-1.5 rounded transition-colors ${
+                                        filterOptions.hideTechnical
+                                            ? 'bg-yellow-500/30 text-yellow-400'
+                                            : 'bg-black/60 text-white/60 hover:text-white hover:bg-white/20'
+                                    }`}
+                                    title={filterOptions.hideTechnical
+                                        ? 'Show Implementation Details'
+                                        : 'Hide Implementation Details (instances, coercions, etc.)'}
                                 >
-                                    <FunnelIcon className="w-4 h-4 text-white/60" />
+                                    <FunnelIcon className="w-4 h-4" />
                                 </button>
-                                */}
 
                                 {/* In-canvas find button - TODO: backend to be developed
                                 <button

--- a/src/hooks/useGraphData.ts
+++ b/src/hooks/useGraphData.ts
@@ -7,7 +7,7 @@
  * Note: This version uses Python backend API instead of Tauri invoke
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react'
 import { loadProject, refreshProject, checkProjectStatus, type ProjectStatus } from '@/lib/api'
 import type { Node, Edge } from '@/types/node'
 import type {
@@ -18,17 +18,34 @@ import type {
   GraphLink,
 } from '@/types/graph'
 import { useFileWatch } from './useFileWatch'
+import {
+  processGraph,
+  type GraphFilterOptions,
+  DEFAULT_FILTER_OPTIONS,
+} from '@/lib/graphProcessing'
 
 // Re-export types for backward compatibility
 export type { GraphNode, GraphLink } from '@/types/graph'
+export type { GraphFilterOptions } from '@/lib/graphProcessing'
+export { DEFAULT_FILTER_OPTIONS } from '@/lib/graphProcessing'
 
 // Node types that require proof status halo (matches backend PROOF_REQUIRING_KINDS)
 const PROOF_REQUIRING_KINDS = ['theorem', 'lemma', 'proposition', 'corollary']
 
+export interface FilterStats {
+  removedNodes: number      // Technical nodes filtered out
+  virtualEdgesCreated: number  // Through-link edges created
+  orphanedNodes: number     // Nodes removed because they became disconnected
+}
+
 export interface GraphData {
-  // New types (internal use)
+  // New types (internal use) - these are PROCESSED (filtered)
   nodes: AstrolabeNode[]
   edges: AstrolabeEdge[]
+
+  // Raw data (unfiltered, for stats)
+  rawNodeCount: number
+  rawEdgeCount: number
 
   // Legacy compatibility (still used by page.tsx and Graph3D)
   legacyNodes: GraphNode[]
@@ -43,6 +60,11 @@ export interface GraphData {
   needsInit: boolean
   notSupported: boolean  // Not a Lean 4 Lake project
   recheckStatus: () => Promise<ProjectStatus | null | undefined>
+
+  // Filtering
+  filterOptions: GraphFilterOptions
+  setFilterOptions: (options: GraphFilterOptions) => void
+  filterStats: FilterStats  // Stats from graph processing
 }
 
 /**
@@ -106,10 +128,11 @@ function backendEdgeToAstrolabe(edge: Edge): AstrolabeEdge {
 }
 
 export function useGraphData(projectPath: string): GraphData {
-  const [nodes, setNodes] = useState<AstrolabeNode[]>([])
-  const [edges, setEdges] = useState<AstrolabeEdge[]>([])
+  const [rawNodes, setRawNodes] = useState<AstrolabeNode[]>([])
+  const [rawEdges, setRawEdges] = useState<AstrolabeEdge[]>([])
   const [loading, setLoading] = useState(false)
   const [projectStatus, setProjectStatus] = useState<ProjectStatus | null>(null)
+  const [filterOptions, setFilterOptions] = useState<GraphFilterOptions>(DEFAULT_FILTER_OPTIONS)
   const loadedRef = useRef(false)
 
   // Check project status
@@ -149,8 +172,8 @@ export function useGraphData(projectPath: string): GraphData {
       const astrolabeNodes = response.nodes.map(backendNodeToAstrolabe)
       const astrolabeEdges = response.edges.map(backendEdgeToAstrolabe)
 
-      setNodes(astrolabeNodes)
-      setEdges(astrolabeEdges)
+      setRawNodes(astrolabeNodes)
+      setRawEdges(astrolabeEdges)
 
       console.log(`[useGraphData] Loaded ${astrolabeNodes.length} nodes and ${astrolabeEdges.length} edges from backend`)
 
@@ -167,8 +190,8 @@ export function useGraphData(projectPath: string): GraphData {
 
   const reload = useCallback(async () => {
     loadedRef.current = false
-    setNodes([])
-    setEdges([])
+    setRawNodes([])
+    setRawEdges([])
     setLoading(true)
 
     try {
@@ -180,8 +203,8 @@ export function useGraphData(projectPath: string): GraphData {
       const astrolabeNodes = response.nodes.map(backendNodeToAstrolabe)
       const astrolabeEdges = response.edges.map(backendEdgeToAstrolabe)
 
-      setNodes(astrolabeNodes)
-      setEdges(astrolabeEdges)
+      setRawNodes(astrolabeNodes)
+      setRawEdges(astrolabeEdges)
 
       console.log(`[useGraphData] Reloaded ${astrolabeNodes.length} nodes and ${astrolabeEdges.length} edges`)
     } catch (err) {
@@ -200,8 +223,8 @@ export function useGraphData(projectPath: string): GraphData {
       const astrolabeNodes = response.nodes.map(backendNodeToAstrolabe)
       const astrolabeEdges = response.edges.map(backendEdgeToAstrolabe)
 
-      setNodes(astrolabeNodes)
-      setEdges(astrolabeEdges)
+      setRawNodes(astrolabeNodes)
+      setRawEdges(astrolabeEdges)
 
       console.log(`[useGraphData] Meta refreshed: ${astrolabeNodes.length} nodes`)
     } catch (err) {
@@ -214,6 +237,25 @@ export function useGraphData(projectPath: string): GraphData {
     onRefresh: reload,       // .ilean changes → full reload
     onMetaRefresh: reloadMeta, // meta.json changes → only refresh meta
   })
+
+  // ============================================
+  // Apply graph processing (filtering + through-links)
+  // ============================================
+  const { nodes, edges, stats: filterStats } = useMemo(
+    () => {
+      const result = processGraph(rawNodes, rawEdges, filterOptions)
+      if (filterOptions.hideTechnical && (result.stats.removedNodes > 0 || result.stats.orphanedNodes > 0)) {
+        console.log(
+          `[processGraph] Filtered ${result.stats.removedNodes} technical nodes, ` +
+          `${result.stats.orphanedNodes} orphaned nodes, ` +
+          `created ${result.stats.virtualEdgesCreated} virtual edges. ` +
+          `Result: ${result.nodes.length} nodes, ${result.edges.length} edges`
+        )
+      }
+      return result
+    },
+    [rawNodes, rawEdges, filterOptions]
+  )
 
   // ============================================
   // Legacy compatibility: convert to old types
@@ -244,6 +286,8 @@ export function useGraphData(projectPath: string): GraphData {
   return {
     nodes,
     edges,
+    rawNodeCount: rawNodes.length,
+    rawEdgeCount: rawEdges.length,
     legacyNodes,
     links,
     loading,
@@ -253,5 +297,8 @@ export function useGraphData(projectPath: string): GraphData {
     needsInit: projectStatus?.needsInit ?? false,
     notSupported: projectStatus?.notSupported ?? false,
     recheckStatus,
+    filterOptions,
+    setFilterOptions,
+    filterStats,
   }
 }

--- a/src/lib/__tests__/graphProcessing.patterns.test.ts
+++ b/src/lib/__tests__/graphProcessing.patterns.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Integration test for graph filtering with realistic Lean 4 project patterns
+ *
+ * Uses synthetic data modeled after common Lean 4 patterns:
+ * - Type class instances (Fintype, Group, MulAction)
+ * - Decidable instances for propositions
+ * - Theorems proving MulAction laws (apply_one, apply_mul)
+ * - Definition hierarchies (Hexagram, complement, reverse)
+ *
+ * These patterns are representative of what the filter encounters in real
+ * Lean 4 formalizations (e.g., mathlib, group theory projects).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  isTechnicalNode,
+  processGraph,
+  type GraphFilterOptions,
+} from '../graphProcessing'
+import type { AstrolabeNode, AstrolabeEdge } from '@/types/graph'
+
+// ============================================
+// Test Helpers
+// ============================================
+
+function createNode(overrides: Partial<AstrolabeNode> & { id: string; name: string }): AstrolabeNode {
+  return {
+    kind: 'theorem',
+    status: 'proven',
+    defaultColor: '#A855F7',
+    defaultSize: 1.0,
+    defaultShape: 'sphere',
+    pinned: false,
+    visible: true,
+    ...overrides,
+  }
+}
+
+function createEdge(source: string, target: string): AstrolabeEdge {
+  return {
+    id: `${source}->${target}`,
+    source,
+    target,
+    fromLean: true,
+    defaultColor: '#2ecc71',
+    defaultWidth: 1.0,
+    defaultStyle: 'solid',
+    visible: true,
+  }
+}
+
+// ============================================
+// Realistic Lean 4 Node/Edge Data
+// Models patterns from group theory formalizations
+// ============================================
+
+function createLean4Nodes(): AstrolabeNode[] {
+  return [
+    // === Definitions (should NOT be filtered) ===
+    createNode({ id: 'klein', name: 'IChing.KleinAction', kind: 'inductive' }),
+    createNode({ id: 'hexagram', name: 'IChing.Hexagram', kind: 'definition' }),
+    createNode({ id: 'apply', name: 'IChing.KleinAction.apply', kind: 'definition' }),
+    createNode({ id: 'complement', name: 'IChing.Hexagram.complement', kind: 'definition' }),
+    createNode({ id: 'reverse', name: 'IChing.Hexagram.reverse', kind: 'definition' }),
+    createNode({ id: 'complementReverse', name: 'IChing.Hexagram.complementReverse', kind: 'definition' }),
+    createNode({ id: 'isPalindrome', name: 'IChing.Hexagram.isPalindrome', kind: 'definition' }),
+    createNode({ id: 'isOppositePair', name: 'IChing.isOppositePair', kind: 'definition' }),
+    createNode({ id: 'isReversePair', name: 'IChing.isReversePair', kind: 'definition' }),
+    createNode({ id: 'isEquivariantPair', name: 'IChing.isEquivariantPair', kind: 'definition' }),
+    createNode({ id: 'priorityPartner', name: 'IChing.priorityPartner', kind: 'definition' }),
+
+    // === Theorems (should NOT be filtered) ===
+    createNode({ id: 'apply_one', name: 'IChing.KleinAction.apply_one', kind: 'theorem' }),
+    createNode({ id: 'apply_mul', name: 'IChing.KleinAction.apply_mul', kind: 'theorem' }),
+    createNode({ id: 'complement_involutive', name: 'IChing.Hexagram.complement_involutive', kind: 'theorem' }),
+    createNode({ id: 'reverse_involutive', name: 'IChing.Hexagram.reverse_involutive', kind: 'theorem' }),
+    createNode({ id: 'complement_reverse_comm', name: 'IChing.Hexagram.complement_reverse_comm', kind: 'theorem' }),
+    createNode({ id: 'kingWen_equivariant', name: 'IChing.kingWen_all_equivariant', kind: 'theorem' }),
+    createNode({ id: 'simple_reflection_opt', name: 'IChing.simple_reflection_optimality', kind: 'theorem' }),
+
+    // === Instances (SHOULD be filtered as technical) ===
+    createNode({ id: 'instFintype', name: 'IChing.instFintypeKleinAction', kind: 'instance' }),
+    createNode({ id: 'instGroup', name: 'IChing.instGroupKleinAction', kind: 'instance' }),
+    createNode({ id: 'instMulAction', name: 'IChing.instMulActionKleinActionHexagram', kind: 'instance' }),
+    createNode({ id: 'instDecidablePalindrome', name: 'IChing.instDecidablePredIsPalindrome', kind: 'definition' }), // Detected by name pattern
+    createNode({ id: 'instDecidableOpp', name: 'IChing.instDecidableIsOppositePair', kind: 'definition' }),
+    createNode({ id: 'instDecidableRev', name: 'IChing.instDecidableIsReversePair', kind: 'definition' }),
+    createNode({ id: 'instCoxeter', name: 'IChing.instCoxeterGeneratorKleinAction', kind: 'instance' }),
+  ]
+}
+
+function createLean4Edges(): AstrolabeEdge[] {
+  return [
+    // === Direct definition dependencies ===
+    createEdge('complement', 'hexagram'),
+    createEdge('reverse', 'hexagram'),
+    createEdge('complementReverse', 'complement'),
+    createEdge('complementReverse', 'reverse'),
+    createEdge('apply', 'klein'),
+    createEdge('apply', 'hexagram'),
+    createEdge('isPalindrome', 'hexagram'),
+    createEdge('isPalindrome', 'reverse'),
+    createEdge('isOppositePair', 'complement'),
+    createEdge('isReversePair', 'reverse'),
+    createEdge('isEquivariantPair', 'isOppositePair'),
+    createEdge('isEquivariantPair', 'isReversePair'),
+    createEdge('priorityPartner', 'isPalindrome'),
+    createEdge('priorityPartner', 'complement'),
+    createEdge('priorityPartner', 'reverse'),
+
+    // === Theorem dependencies on definitions ===
+    createEdge('complement_involutive', 'complement'),
+    createEdge('reverse_involutive', 'reverse'),
+    createEdge('complement_reverse_comm', 'complement'),
+    createEdge('complement_reverse_comm', 'reverse'),
+    createEdge('kingWen_equivariant', 'isEquivariantPair'),
+    createEdge('simple_reflection_opt', 'priorityPartner'),
+
+    // === Instance dependencies ===
+    createEdge('instFintype', 'klein'),
+    createEdge('instGroup', 'klein'),
+    createEdge('instGroup', 'instFintype'),  // Group depends on Fintype
+    createEdge('instMulAction', 'klein'),
+    createEdge('instMulAction', 'hexagram'),
+    createEdge('instMulAction', 'apply'),
+    createEdge('instMulAction', 'instGroup'),
+    createEdge('instDecidablePalindrome', 'isPalindrome'),
+    createEdge('instDecidableOpp', 'isOppositePair'),
+    createEdge('instDecidableRev', 'isReversePair'),
+    createEdge('instCoxeter', 'klein'),
+    createEdge('instCoxeter', 'instGroup'),
+
+    // === MulAction theorem dependencies (the key case!) ===
+    // apply_one and apply_mul ONLY depend on the MulAction instance
+    createEdge('apply_one', 'instMulAction'),
+    createEdge('apply_mul', 'instMulAction'),
+  ]
+}
+
+// ============================================
+// Integration Tests
+// ============================================
+
+describe('Lean 4 Pattern Integration Tests', () => {
+  const nodes = createLean4Nodes()
+  const edges = createLean4Edges()
+
+  describe('isTechnicalNode detection', () => {
+    it('should identify all instance nodes as technical', () => {
+      const instanceNodes = nodes.filter(n => n.kind === 'instance')
+      for (const node of instanceNodes) {
+        expect(isTechnicalNode(node), `${node.name} should be technical`).toBe(true)
+      }
+    })
+
+    it('should identify instDecidable* nodes as technical (by name pattern)', () => {
+      const decidableNodes = nodes.filter(n => n.name.includes('instDecidable'))
+      expect(decidableNodes.length).toBeGreaterThan(0)
+      for (const node of decidableNodes) {
+        expect(isTechnicalNode(node), `${node.name} should be technical`).toBe(true)
+      }
+    })
+
+    it('should NOT identify regular definitions as technical', () => {
+      const regularDefs = ['complement', 'reverse', 'apply', 'isPalindrome', 'priorityPartner']
+      for (const id of regularDefs) {
+        const node = nodes.find(n => n.id === id)!
+        expect(isTechnicalNode(node), `${node.name} should NOT be technical`).toBe(false)
+      }
+    })
+
+    it('should NOT identify regular theorems as technical', () => {
+      const theorems = nodes.filter(n => n.kind === 'theorem')
+      for (const node of theorems) {
+        expect(isTechnicalNode(node), `${node.name} should NOT be technical`).toBe(false)
+      }
+    })
+  })
+
+  describe('processGraph with leanichi data', () => {
+    it('should filter correct number of technical nodes', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      // Count expected technical nodes:
+      // 4 instance kind + 3 instDecidable* by name = 7 technical
+      expect(result.stats.removedNodes).toBe(7)
+    })
+
+    it('should keep apply_one and apply_mul via through-links (instance has outgoing deps)', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      // apply_one -> instMulAction -> apply, klein, hexagram
+      // So through-links are created: apply_one -> apply, apply_one -> klein, etc.
+      // This means apply_one is NOT orphaned!
+      const remainingIds = result.nodes.map(n => n.id)
+      expect(remainingIds).toContain('apply_one')
+      expect(remainingIds).toContain('apply_mul')
+
+      // Verify they have through-link edges
+      const virtualEdges = result.edges.filter(e => e.id.startsWith('virtual'))
+      const applyOneEdges = virtualEdges.filter(e => e.source === 'apply_one')
+      const applyMulEdges = virtualEdges.filter(e => e.source === 'apply_mul')
+
+      // Each should have edges to: apply, klein, hexagram (3 edges each)
+      expect(applyOneEdges.length).toBeGreaterThan(0)
+      expect(applyMulEdges.length).toBeGreaterThan(0)
+    })
+
+    it('should keep apply_one and apply_mul with hideOrphaned: false', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: false })
+
+      const remainingIds = result.nodes.map(n => n.id)
+      expect(remainingIds).toContain('apply_one')
+      expect(remainingIds).toContain('apply_mul')
+      expect(result.stats.orphanedNodes).toBe(0)
+    })
+
+    it('should keep core definitions after filtering', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      const remainingIds = result.nodes.map(n => n.id)
+      const expectedKept = [
+        'hexagram', 'klein', 'complement', 'reverse', 'complementReverse',
+        'isPalindrome', 'isOppositePair', 'isReversePair', 'isEquivariantPair',
+        'priorityPartner', 'apply',
+        'complement_involutive', 'reverse_involutive', 'complement_reverse_comm',
+        'kingWen_equivariant', 'simple_reflection_opt'
+      ]
+
+      for (const id of expectedKept) {
+        expect(remainingIds, `${id} should be kept`).toContain(id)
+      }
+    })
+
+    it('should create through-links for apply_one/apply_mul to instance dependencies', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: false })
+
+      // instMulAction depends ON: apply, klein, hexagram
+      // apply_one -> instMulAction, so through-links: apply_one -> apply, klein, hexagram
+      const virtualEdges = result.edges.filter(e => e.id.startsWith('virtual'))
+      const applyOneOutgoing = virtualEdges.filter(e => e.source === 'apply_one')
+      const applyMulOutgoing = virtualEdges.filter(e => e.source === 'apply_mul')
+
+      // Each gets through-links to the 3 non-technical deps of instMulAction
+      expect(applyOneOutgoing.length).toBe(3)
+      expect(applyMulOutgoing.length).toBe(3)
+
+      // Verify targets are the right nodes
+      const applyOneTargets = applyOneOutgoing.map(e => e.target).sort()
+      expect(applyOneTargets).toEqual(['apply', 'hexagram', 'klein'])
+    })
+
+    it('should remove edges to technical nodes', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      // No edge should reference a technical node
+      const technicalIds = ['instFintype', 'instGroup', 'instMulAction',
+                           'instDecidablePalindrome', 'instDecidableOpp',
+                           'instDecidableRev', 'instCoxeter']
+
+      for (const edge of result.edges) {
+        expect(technicalIds).not.toContain(edge.source)
+        expect(technicalIds).not.toContain(edge.target)
+      }
+    })
+
+    it('should preserve direct definition-to-definition edges', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      // These edges don't go through any instance
+      const expectedEdges = [
+        ['complement', 'hexagram'],
+        ['reverse', 'hexagram'],
+        ['complement_involutive', 'complement'],
+        ['reverse_involutive', 'reverse'],
+      ]
+
+      for (const [source, target] of expectedEdges) {
+        const found = result.edges.find(e => e.source === source && e.target === target)
+        expect(found, `Edge ${source} -> ${target} should exist`).toBeDefined()
+      }
+    })
+  })
+
+  describe('orphaning scenario (instance with no non-technical outgoing)', () => {
+    it('should orphan nodes when instance has only technical dependencies', () => {
+      // Simulate: theorem -> instance -> anotherInstance (chain of technical)
+      const isolatedNodes: AstrolabeNode[] = [
+        createNode({ id: 'theorem1', name: 'Some.theorem', kind: 'theorem' }),
+        createNode({ id: 'inst1', name: 'instA', kind: 'instance' }),
+        createNode({ id: 'inst2', name: 'instB', kind: 'instance' }),
+      ]
+      const isolatedEdges: AstrolabeEdge[] = [
+        createEdge('theorem1', 'inst1'),
+        createEdge('inst1', 'inst2'),  // instance depends on another instance only
+      ]
+
+      const result = processGraph(isolatedNodes, isolatedEdges, { hideTechnical: true, hideOrphaned: true })
+
+      // Both instances filtered, theorem1 becomes orphaned
+      expect(result.stats.removedNodes).toBe(2)
+      expect(result.stats.orphanedNodes).toBe(1)
+      expect(result.nodes).toHaveLength(0)
+    })
+
+    it('should orphan nodes when instance has no outgoing edges at all', () => {
+      // The classic "dead-end instance" pattern
+      const deadEndNodes: AstrolabeNode[] = [
+        createNode({ id: 'thm', name: 'MyTheorem', kind: 'theorem' }),
+        createNode({ id: 'inst', name: 'instDeadEnd', kind: 'instance' }),
+      ]
+      const deadEndEdges: AstrolabeEdge[] = [
+        createEdge('thm', 'inst'),  // theorem uses instance, but instance uses nothing
+      ]
+
+      const result = processGraph(deadEndNodes, deadEndEdges, { hideTechnical: true, hideOrphaned: true })
+
+      expect(result.stats.removedNodes).toBe(1)  // instance
+      expect(result.stats.orphanedNodes).toBe(1)  // theorem
+      expect(result.nodes).toHaveLength(0)
+    })
+  })
+
+  describe('stats accuracy', () => {
+    it('should report accurate counts', () => {
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      console.log('=== Lean 4 Filter Stats ===')
+      console.log(`Original: ${nodes.length} nodes, ${edges.length} edges`)
+      console.log(`Technical removed: ${result.stats.removedNodes}`)
+      console.log(`Orphaned removed: ${result.stats.orphanedNodes}`)
+      console.log(`Virtual edges created: ${result.stats.virtualEdgesCreated}`)
+      console.log(`Final: ${result.nodes.length} nodes, ${result.edges.length} edges`)
+      console.log(`Hidden total: ${result.stats.removedNodes + result.stats.orphanedNodes}`)
+
+      // Verify math adds up
+      const totalRemoved = result.stats.removedNodes + result.stats.orphanedNodes
+      expect(nodes.length - totalRemoved).toBe(result.nodes.length)
+    })
+  })
+})

--- a/src/lib/__tests__/graphProcessing.test.ts
+++ b/src/lib/__tests__/graphProcessing.test.ts
@@ -1,0 +1,651 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isTechnicalNode,
+  processGraph,
+  getTechnicalNodeIds,
+  DEFAULT_FILTER_OPTIONS,
+  type GraphFilterOptions,
+} from '../graphProcessing'
+import type { AstrolabeNode, AstrolabeEdge } from '@/types/graph'
+
+// ============================================
+// Test Helpers
+// ============================================
+
+function createNode(overrides: Partial<AstrolabeNode> & { id: string; name: string }): AstrolabeNode {
+  return {
+    kind: 'theorem',
+    status: 'proven',
+    defaultColor: '#A855F7',
+    defaultSize: 1.0,
+    defaultShape: 'sphere',
+    pinned: false,
+    visible: true,
+    ...overrides,
+  }
+}
+
+function createEdge(source: string, target: string, id?: string): AstrolabeEdge {
+  return {
+    id: id || `${source}->${target}`,
+    source,
+    target,
+    fromLean: true,
+    defaultColor: '#2ecc71',
+    defaultWidth: 1.0,
+    defaultStyle: 'solid',
+    visible: true,
+  }
+}
+
+// ============================================
+// isTechnicalNode Tests
+// ============================================
+
+describe('isTechnicalNode', () => {
+  describe('instance and class kinds', () => {
+    it('should identify instance kind as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.myInstance', kind: 'instance' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify class kind as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.MyClass', kind: 'class' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should not identify theorem kind as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.myTheorem', kind: 'theorem' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+
+    it('should not identify definition kind as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.myDef', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+  })
+
+  describe('inst prefix patterns', () => {
+    it('should identify names starting with inst as technical', () => {
+      const node = createNode({ id: '1', name: 'instDecidableEq', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify names containing .inst as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.instRepr', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should not identify names containing inst in middle', () => {
+      const node = createNode({ id: '1', name: 'MyModule.instrument', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+  })
+
+  describe('coercion patterns', () => {
+    it('should identify _of_ coercions as technical', () => {
+      const node = createNode({ id: '1', name: 'Int_of_Nat', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify .of_ coercions as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.of_something', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify _to_ conversions as technical', () => {
+      const node = createNode({ id: '1', name: 'Nat_to_Int', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify .to_ conversions as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.to_string', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+  })
+
+  describe('auto-generated names', () => {
+    it('should identify names starting with underscore as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule._private', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify numeric suffix names as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.auto.123', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+  })
+
+  describe('Decidable patterns', () => {
+    it('should identify Decidable as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.DecidableEq', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify decidable (lowercase) as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.decidable_of_bool', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+  })
+
+  describe('type class projections', () => {
+    it('should identify mk as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.mk', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should identify mk1 as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.mk1', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(true)
+    })
+
+    it('should not identify mkSomething as technical', () => {
+      const node = createNode({ id: '1', name: 'MyModule.mkSomething', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+  })
+
+  describe('non-technical nodes', () => {
+    it('should not identify regular theorems as technical', () => {
+      const node = createNode({ id: '1', name: 'IChing.Hexagram.complement_involutive', kind: 'theorem' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+
+    it('should not identify regular lemmas as technical', () => {
+      const node = createNode({ id: '1', name: 'Nat.add_comm', kind: 'lemma' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+
+    it('should not identify regular definitions as technical', () => {
+      const node = createNode({ id: '1', name: 'List.map', kind: 'definition' })
+      expect(isTechnicalNode(node)).toBe(false)
+    })
+  })
+})
+
+// ============================================
+// processGraph Tests
+// ============================================
+
+describe('processGraph', () => {
+  describe('with hideTechnical: false', () => {
+    it('should return nodes and edges unchanged', () => {
+      const nodes = [
+        createNode({ id: '1', name: 'Theorem1', kind: 'theorem' }),
+        createNode({ id: '2', name: 'instDecidable', kind: 'instance' }),
+      ]
+      const edges = [createEdge('1', '2')]
+
+      const result = processGraph(nodes, edges, { hideTechnical: false, hideOrphaned: true })
+
+      expect(result.nodes).toHaveLength(2)
+      expect(result.edges).toHaveLength(1)
+      expect(result.stats.removedNodes).toBe(0)
+      expect(result.stats.virtualEdgesCreated).toBe(0)
+      expect(result.stats.orphanedNodes).toBe(0)
+    })
+  })
+
+  describe('with hideTechnical: true', () => {
+    it('should remove technical nodes', () => {
+      const nodes = [
+        createNode({ id: '1', name: 'Theorem1', kind: 'theorem' }),
+        createNode({ id: '2', name: 'instDecidable', kind: 'instance' }),
+        createNode({ id: '3', name: 'Definition1', kind: 'definition' }),
+      ]
+      // Add an edge so nodes aren't orphaned
+      const edges = [createEdge('1', '3')]
+
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      expect(result.nodes).toHaveLength(2)
+      expect(result.nodes.map(n => n.id)).toEqual(['1', '3'])
+      expect(result.stats.removedNodes).toBe(1)
+    })
+
+    it('should remove edges connected to technical nodes', () => {
+      const nodes = [
+        createNode({ id: '1', name: 'Theorem1', kind: 'theorem' }),
+        createNode({ id: '2', name: 'instDecidable', kind: 'instance' }),
+        createNode({ id: '3', name: 'OtherTheorem', kind: 'theorem' }),
+      ]
+      // Add a real connection between non-technical nodes
+      const edges = [createEdge('1', '2'), createEdge('1', '3')]
+
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      // Should only have the edge between non-technical nodes
+      expect(result.edges).toHaveLength(1)
+      expect(result.edges[0].source).toBe('1')
+      expect(result.edges[0].target).toBe('3')
+    })
+
+    describe('through-links (graph contraction)', () => {
+      it('should create virtual edge when hiding intermediate node', () => {
+        // A -> T -> B  =>  A -> B (virtual)
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T', name: 'instTechnical', kind: 'instance' }),
+          createNode({ id: 'B', name: 'DefinitionB', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T'),
+          createEdge('T', 'B'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(2)
+        expect(result.nodes.map(n => n.id)).toEqual(['A', 'B'])
+
+        expect(result.edges).toHaveLength(1)
+        expect(result.edges[0].source).toBe('A')
+        expect(result.edges[0].target).toBe('B')
+        expect(result.edges[0].id).toContain('virtual')
+        expect(result.edges[0].style).toBe('dashed')
+        expect(result.edges[0].fromLean).toBe(false)
+
+        expect(result.stats.virtualEdgesCreated).toBe(1)
+      })
+
+      it('should create multiple virtual edges for fan-out pattern', () => {
+        // A -> T -> B
+        //      T -> C
+        // =>  A -> B, A -> C
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T', name: 'instTechnical', kind: 'instance' }),
+          createNode({ id: 'B', name: 'DefB', kind: 'definition' }),
+          createNode({ id: 'C', name: 'DefC', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T'),
+          createEdge('T', 'B'),
+          createEdge('T', 'C'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(3)
+        expect(result.edges).toHaveLength(2)
+        expect(result.stats.virtualEdgesCreated).toBe(2)
+
+        const virtualEdges = result.edges.filter(e => e.id.startsWith('virtual'))
+        expect(virtualEdges).toHaveLength(2)
+
+        const targets = virtualEdges.map(e => e.target).sort()
+        expect(targets).toEqual(['B', 'C'])
+      })
+
+      it('should create multiple virtual edges for fan-in pattern', () => {
+        // A -> T -> C
+        // B -> T
+        // =>  A -> C, B -> C
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'B', name: 'TheoremB', kind: 'theorem' }),
+          createNode({ id: 'T', name: 'instTechnical', kind: 'instance' }),
+          createNode({ id: 'C', name: 'DefC', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T'),
+          createEdge('B', 'T'),
+          createEdge('T', 'C'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(3)
+        expect(result.edges).toHaveLength(2)
+        expect(result.stats.virtualEdgesCreated).toBe(2)
+
+        const sources = result.edges.map(e => e.source).sort()
+        expect(sources).toEqual(['A', 'B'])
+      })
+
+      it('should not create self-loops', () => {
+        // A -> T -> A (should not create A -> A)
+        // With hideOrphaned, A will be removed since it has no edges
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T', name: 'instTechnical', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('A', 'T'),
+          createEdge('T', 'A'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: false })
+
+        expect(result.edges).toHaveLength(0)
+        expect(result.stats.virtualEdgesCreated).toBe(0)
+      })
+
+      it('should not create duplicate virtual edges', () => {
+        // A -> T1 -> B
+        // A -> T2 -> B
+        // => Only one A -> B
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T1', name: 'instTech1', kind: 'instance' }),
+          createNode({ id: 'T2', name: 'instTech2', kind: 'instance' }),
+          createNode({ id: 'B', name: 'DefB', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T1'),
+          createEdge('T1', 'B'),
+          createEdge('A', 'T2'),
+          createEdge('T2', 'B'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.edges).toHaveLength(1)
+        expect(result.edges[0].source).toBe('A')
+        expect(result.edges[0].target).toBe('B')
+      })
+
+      it('should not create virtual edge if real edge already exists', () => {
+        // A -> T -> B
+        // A -> B (direct)
+        // => Only keep A -> B (direct), no virtual
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T', name: 'instTechnical', kind: 'instance' }),
+          createNode({ id: 'B', name: 'DefB', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T'),
+          createEdge('T', 'B'),
+          createEdge('A', 'B'),  // Direct edge
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.edges).toHaveLength(1)
+        expect(result.edges[0].id).toBe('A->B')  // Original, not virtual
+        expect(result.stats.virtualEdgesCreated).toBe(0)
+      })
+
+      it('should handle chain of technical nodes', () => {
+        // A -> T1 -> T2 -> B
+        // Only T1's through-links to non-technical nodes are created
+        // T2's incoming is T1 (technical), so no through-link from A
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T1', name: 'instTech1', kind: 'instance' }),
+          createNode({ id: 'T2', name: 'instTech2', kind: 'instance' }),
+          createNode({ id: 'B', name: 'DefB', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T1'),
+          createEdge('T1', 'T2'),
+          createEdge('T2', 'B'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: false })
+
+        // A and B remain (with hideOrphaned: false)
+        expect(result.nodes).toHaveLength(2)
+        // No through-links because T1's output goes to T2 (also technical)
+        // and T2's input comes from T1 (also technical)
+        expect(result.edges).toHaveLength(0)
+      })
+
+      it('should handle mixed technical and non-technical connections', () => {
+        // A -> T -> B
+        // A -> C (direct)
+        // T -> D
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'T', name: 'instTech', kind: 'instance' }),
+          createNode({ id: 'B', name: 'DefB', kind: 'definition' }),
+          createNode({ id: 'C', name: 'DefC', kind: 'definition' }),
+          createNode({ id: 'D', name: 'DefD', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('A', 'T'),
+          createEdge('T', 'B'),
+          createEdge('A', 'C'),
+          createEdge('T', 'D'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(4)  // A, B, C, D
+        expect(result.edges).toHaveLength(3)  // A->C (real), A->B (virtual), A->D (virtual)
+
+        const realEdges = result.edges.filter(e => !e.id.startsWith('virtual'))
+        const virtualEdges = result.edges.filter(e => e.id.startsWith('virtual'))
+
+        expect(realEdges).toHaveLength(1)
+        expect(realEdges[0].id).toBe('A->C')
+
+        expect(virtualEdges).toHaveLength(2)
+      })
+    })
+
+    it('should handle empty graph', () => {
+      const result = processGraph([], [], { hideTechnical: true, hideOrphaned: true })
+
+      expect(result.nodes).toHaveLength(0)
+      expect(result.edges).toHaveLength(0)
+      expect(result.stats.removedNodes).toBe(0)
+      expect(result.stats.orphanedNodes).toBe(0)
+    })
+
+    it('should handle graph with no technical nodes', () => {
+      const nodes = [
+        createNode({ id: '1', name: 'Theorem1', kind: 'theorem' }),
+        createNode({ id: '2', name: 'Definition1', kind: 'definition' }),
+      ]
+      const edges = [createEdge('1', '2')]
+
+      const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+      expect(result.nodes).toHaveLength(2)
+      expect(result.edges).toHaveLength(1)
+      expect(result.stats.removedNodes).toBe(0)
+      expect(result.stats.orphanedNodes).toBe(0)
+    })
+
+    describe('orphaned node removal', () => {
+      it('should remove nodes that become orphaned after filtering', () => {
+        // apply_one -> instMulAction (no outgoing from instance)
+        // With hideOrphaned: true, apply_one should be removed
+        const nodes = [
+          createNode({ id: 'apply_one', name: 'IChing.apply_one', kind: 'theorem' }),
+          createNode({ id: 'inst', name: 'instMulActionHexagram', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('apply_one', 'inst'),  // apply_one uses the instance
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(0)  // Both removed (inst is technical, apply_one becomes orphaned)
+        expect(result.edges).toHaveLength(0)
+        expect(result.stats.removedNodes).toBe(1)  // inst removed as technical
+        expect(result.stats.orphanedNodes).toBe(1)  // apply_one removed as orphaned
+      })
+
+      it('should keep orphaned nodes when hideOrphaned is false', () => {
+        const nodes = [
+          createNode({ id: 'apply_one', name: 'IChing.apply_one', kind: 'theorem' }),
+          createNode({ id: 'inst', name: 'instMulActionHexagram', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('apply_one', 'inst'),
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: false })
+
+        expect(result.nodes).toHaveLength(1)  // apply_one kept
+        expect(result.nodes[0].id).toBe('apply_one')
+        expect(result.stats.orphanedNodes).toBe(0)
+      })
+
+      it('should not remove nodes that still have connections after filtering', () => {
+        const nodes = [
+          createNode({ id: 'theorem1', name: 'Theorem1', kind: 'theorem' }),
+          createNode({ id: 'inst', name: 'instSomething', kind: 'instance' }),
+          createNode({ id: 'def1', name: 'Definition1', kind: 'definition' }),
+        ]
+        const edges = [
+          createEdge('theorem1', 'inst'),
+          createEdge('inst', 'def1'),  // through-link will be created
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(2)  // theorem1 and def1
+        expect(result.nodes.map(n => n.id).sort()).toEqual(['def1', 'theorem1'])
+        expect(result.edges).toHaveLength(1)  // virtual edge theorem1 -> def1
+        expect(result.stats.orphanedNodes).toBe(0)
+      })
+
+      it('should handle multiple orphaned nodes', () => {
+        // Multiple nodes only connect to the same instance
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'B', name: 'TheoremB', kind: 'theorem' }),
+          createNode({ id: 'C', name: 'TheoremC', kind: 'theorem' }),
+          createNode({ id: 'inst', name: 'instTech', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('A', 'inst'),
+          createEdge('B', 'inst'),
+          createEdge('C', 'inst'),
+          // No outgoing edges from inst
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(0)
+        expect(result.stats.orphanedNodes).toBe(3)  // A, B, C all orphaned
+      })
+
+      it('should keep nodes connected via through-links', () => {
+        // A -> inst -> B
+        // C -> inst -> B (C also gets a through-link to B!)
+        // All nodes should be kept (A, B, C connected via through-links)
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'B', name: 'DefB', kind: 'definition' }),
+          createNode({ id: 'C', name: 'TheoremC', kind: 'theorem' }),
+          createNode({ id: 'inst', name: 'instTech', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('A', 'inst'),
+          createEdge('inst', 'B'),
+          createEdge('C', 'inst'),  // C -> inst -> B creates C -> B through-link
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        // All non-technical nodes kept - both A and C get through-links to B
+        expect(result.nodes).toHaveLength(3)  // A, B, C
+        expect(result.nodes.map(n => n.id).sort()).toEqual(['A', 'B', 'C'])
+        expect(result.edges).toHaveLength(2)  // A -> B and C -> B
+        expect(result.stats.orphanedNodes).toBe(0)
+      })
+
+      it('should orphan nodes that only connect TO an instance with no outgoing', () => {
+        // A -> inst1 (no outgoing from inst1)
+        // B -> inst1
+        // A and B become orphaned
+        const nodes = [
+          createNode({ id: 'A', name: 'TheoremA', kind: 'theorem' }),
+          createNode({ id: 'B', name: 'TheoremB', kind: 'theorem' }),
+          createNode({ id: 'inst1', name: 'instTech1', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('A', 'inst1'),
+          createEdge('B', 'inst1'),
+          // No outgoing from inst1, so no through-links possible
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.nodes).toHaveLength(0)
+        expect(result.stats.orphanedNodes).toBe(2)  // A and B
+      })
+
+      it('should correctly count orphaned nodes in stats', () => {
+        // Scenario: inst1 has no outgoing, inst2 has outgoing
+        // 1 -> inst1 (orphaned - no through-link possible)
+        // 2 -> inst1 (orphaned - no through-link possible)
+        // 4 -> inst2 -> 5 (connected via through-link)
+        const nodes = [
+          createNode({ id: '1', name: 'Orphan1', kind: 'theorem' }),
+          createNode({ id: '2', name: 'Orphan2', kind: 'theorem' }),
+          createNode({ id: 'inst1', name: 'instTech1', kind: 'instance' }),
+          createNode({ id: '4', name: 'Connected1', kind: 'theorem' }),
+          createNode({ id: '5', name: 'Connected2', kind: 'definition' }),
+          createNode({ id: 'inst2', name: 'instTech2', kind: 'instance' }),
+        ]
+        const edges = [
+          createEdge('1', 'inst1'),  // Will be orphaned (no outgoing from inst1)
+          createEdge('2', 'inst1'),  // Will be orphaned (no outgoing from inst1)
+          createEdge('4', 'inst2'),
+          createEdge('inst2', '5'),  // Through-link: 4 -> 5
+        ]
+
+        const result = processGraph(nodes, edges, { hideTechnical: true, hideOrphaned: true })
+
+        expect(result.stats.removedNodes).toBe(2)  // inst1 and inst2
+        expect(result.stats.orphanedNodes).toBe(2)  // 1 and 2
+        expect(result.stats.virtualEdgesCreated).toBe(1)  // 4 -> 5
+        expect(result.nodes).toHaveLength(2)  // 4 and 5
+      })
+    })
+  })
+})
+
+// ============================================
+// getTechnicalNodeIds Tests
+// ============================================
+
+describe('getTechnicalNodeIds', () => {
+  it('should return set of technical node IDs', () => {
+    const nodes = [
+      createNode({ id: '1', name: 'Theorem1', kind: 'theorem' }),
+      createNode({ id: '2', name: 'instDecidable', kind: 'instance' }),
+      createNode({ id: '3', name: 'Definition1', kind: 'definition' }),
+      createNode({ id: '4', name: 'MyClass', kind: 'class' }),
+    ]
+
+    const technicalIds = getTechnicalNodeIds(nodes)
+
+    expect(technicalIds.size).toBe(2)
+    expect(technicalIds.has('2')).toBe(true)
+    expect(technicalIds.has('4')).toBe(true)
+    expect(technicalIds.has('1')).toBe(false)
+    expect(technicalIds.has('3')).toBe(false)
+  })
+
+  it('should return empty set for no technical nodes', () => {
+    const nodes = [
+      createNode({ id: '1', name: 'Theorem1', kind: 'theorem' }),
+      createNode({ id: '2', name: 'Definition1', kind: 'definition' }),
+    ]
+
+    const technicalIds = getTechnicalNodeIds(nodes)
+
+    expect(technicalIds.size).toBe(0)
+  })
+})
+
+// ============================================
+// DEFAULT_FILTER_OPTIONS Tests
+// ============================================
+
+describe('DEFAULT_FILTER_OPTIONS', () => {
+  it('should have hideTechnical set to false by default', () => {
+    expect(DEFAULT_FILTER_OPTIONS.hideTechnical).toBe(false)
+  })
+
+  it('should have hideOrphaned set to true by default', () => {
+    expect(DEFAULT_FILTER_OPTIONS.hideOrphaned).toBe(true)
+  })
+})

--- a/src/lib/graphProcessing.ts
+++ b/src/lib/graphProcessing.ts
@@ -1,0 +1,238 @@
+/**
+ * Graph Processing Utilities
+ *
+ * Pure functions for filtering and transforming graph data.
+ * These are extracted from useGraphData for testability and reuse.
+ */
+
+import type { AstrolabeNode, AstrolabeEdge } from '@/types/graph'
+
+// ============================================
+// Filter Options
+// ============================================
+
+export interface GraphFilterOptions {
+  hideTechnical: boolean  // Hide instances, generated coercions, etc.
+  hideOrphaned: boolean   // Auto-hide nodes that become disconnected after filtering
+}
+
+export const DEFAULT_FILTER_OPTIONS: GraphFilterOptions = {
+  hideTechnical: false,
+  hideOrphaned: true,  // Default to true - orphaned nodes are usually not useful
+}
+
+// ============================================
+// Technical Node Detection
+// ============================================
+
+/**
+ * Check if a node is "technical" (implementation detail)
+ * These nodes clutter the graph without adding conceptual value
+ *
+ * Technical nodes include:
+ * - Type class instances (instance, class kinds)
+ * - Auto-generated names (instDecidable, instRepr, etc.)
+ * - Generated coercions and conversions (_of_, _to_)
+ * - Decidability instances
+ * - Type class projections (mk, mk1, etc.)
+ */
+export function isTechnicalNode(node: AstrolabeNode): boolean {
+  const name = node.name
+  const kind = node.kind.toLowerCase()
+
+  // 1. Instance nodes (type class machinery)
+  if (kind === 'instance' || kind === 'class') return true
+
+  // Get the last segment of the name (after the last dot)
+  const lastPart = name.split('.').pop() || ''
+
+  // 2. Names where last segment starts with 'inst' followed by uppercase or end
+  // Matches: instDecidable, instRepr, inst (but not: instrument, instance as regular word)
+  if (/^inst([A-Z]|$)/.test(lastPart)) return true
+
+  // 3. Generated coercions and conversions
+  if (name.includes('_of_') || name.includes('.of_')) return true
+  if (name.includes('_to_') || name.includes('.to_')) return true
+
+  // 4. Auto-generated names (often start with underscore or have numeric suffixes)
+  if (lastPart.startsWith('_') || /\.\d+$/.test(name)) return true
+
+  // 5. Decidability instances
+  if (name.includes('Decidable') || name.includes('decidable')) return true
+
+  // 6. Type class projections
+  if (lastPart.startsWith('mk') && lastPart.length <= 4) return true
+
+  return false
+}
+
+// ============================================
+// Graph Contraction (Through-Links)
+// ============================================
+
+export interface ProcessGraphResult {
+  nodes: AstrolabeNode[]
+  edges: AstrolabeEdge[]
+  stats: {
+    removedNodes: number
+    virtualEdgesCreated: number
+    orphanedNodes: number  // Nodes removed because they became disconnected
+  }
+}
+
+/**
+ * Process graph with filtering and through-links (graph contraction)
+ *
+ * When a technical node T is hidden:
+ * - If A -> T and T -> B, create virtual edge A -> B
+ * - Remove T and all its direct edges
+ *
+ * This preserves the logical dependency chain while hiding implementation details.
+ *
+ * @param nodes - All nodes in the graph
+ * @param edges - All edges in the graph
+ * @param options - Filter options
+ * @returns Processed graph with filtered nodes and through-link edges
+ */
+export function processGraph(
+  nodes: AstrolabeNode[],
+  edges: AstrolabeEdge[],
+  options: GraphFilterOptions
+): ProcessGraphResult {
+  if (!options.hideTechnical) {
+    return {
+      nodes,
+      edges,
+      stats: { removedNodes: 0, virtualEdgesCreated: 0, orphanedNodes: 0 }
+    }
+  }
+
+  // Identify technical nodes
+  const technicalIds = new Set<string>()
+
+  for (const node of nodes) {
+    if (isTechnicalNode(node)) {
+      technicalIds.add(node.id)
+    }
+  }
+
+  // If no technical nodes, return as-is
+  if (technicalIds.size === 0) {
+    return {
+      nodes,
+      edges,
+      stats: { removedNodes: 0, virtualEdgesCreated: 0, orphanedNodes: 0 }
+    }
+  }
+
+  // Build adjacency lists for through-link computation
+  const incomingEdges = new Map<string, AstrolabeEdge[]>()  // target -> edges
+  const outgoingEdges = new Map<string, AstrolabeEdge[]>()  // source -> edges
+
+  for (const edge of edges) {
+    if (!incomingEdges.has(edge.target)) incomingEdges.set(edge.target, [])
+    if (!outgoingEdges.has(edge.source)) outgoingEdges.set(edge.source, [])
+    incomingEdges.get(edge.target)!.push(edge)
+    outgoingEdges.get(edge.source)!.push(edge)
+  }
+
+  // Create through-links for each technical node
+  const virtualEdges: AstrolabeEdge[] = []
+  const seenVirtualEdges = new Set<string>()  // Prevent duplicates
+
+  // Also track existing edges to avoid duplicates
+  const existingEdgeKeys = new Set(
+    edges.map(e => `${e.source}->${e.target}`)
+  )
+
+  for (const techId of technicalIds) {
+    const incoming = incomingEdges.get(techId) || []
+    const outgoing = outgoingEdges.get(techId) || []
+
+    // For each pair of (incoming source, outgoing target), create virtual edge
+    for (const inEdge of incoming) {
+      // Skip if source is also technical (will be handled when processing that node)
+      if (technicalIds.has(inEdge.source)) continue
+
+      for (const outEdge of outgoing) {
+        // Skip if target is also technical
+        if (technicalIds.has(outEdge.target)) continue
+
+        // Skip self-loops
+        if (inEdge.source === outEdge.target) continue
+
+        const edgeKey = `${inEdge.source}->${outEdge.target}`
+        const virtualId = `virtual-${edgeKey}`
+
+        // Skip if we already have this edge (real or virtual)
+        if (seenVirtualEdges.has(virtualId)) continue
+        if (existingEdgeKeys.has(edgeKey)) continue
+
+        seenVirtualEdges.add(virtualId)
+
+        virtualEdges.push({
+          id: virtualId,
+          source: inEdge.source,
+          target: outEdge.target,
+          fromLean: false,
+          defaultColor: '#6b7280',  // Gray for virtual edges
+          defaultWidth: 0.8,
+          defaultStyle: 'dashed',
+          style: 'dashed',
+          visible: true,
+        })
+      }
+    }
+  }
+
+  // Filter out technical nodes
+  const filteredNodes = nodes.filter(n => !technicalIds.has(n.id))
+
+  // Filter out edges connected to technical nodes, add virtual edges
+  const filteredEdges = edges.filter(
+    e => !technicalIds.has(e.source) && !technicalIds.has(e.target)
+  )
+
+  let finalEdges = [...filteredEdges, ...virtualEdges]
+  let finalNodes = filteredNodes
+
+  // If hideOrphaned is enabled (default), remove nodes that became disconnected
+  let orphanedCount = 0
+  if (options.hideOrphaned !== false) {
+    // Find nodes that have at least one edge
+    const connectedNodeIds = new Set<string>()
+    for (const edge of finalEdges) {
+      connectedNodeIds.add(edge.source)
+      connectedNodeIds.add(edge.target)
+    }
+
+    // Filter out orphaned nodes (nodes with no edges)
+    const nodesBeforeOrphanRemoval = finalNodes.length
+    finalNodes = finalNodes.filter(n => connectedNodeIds.has(n.id))
+    orphanedCount = nodesBeforeOrphanRemoval - finalNodes.length
+  }
+
+  return {
+    nodes: finalNodes,
+    edges: finalEdges,
+    stats: {
+      removedNodes: technicalIds.size,
+      virtualEdgesCreated: virtualEdges.length,
+      orphanedNodes: orphanedCount
+    }
+  }
+}
+
+/**
+ * Get IDs of all technical nodes without processing
+ * Useful for highlighting or counting without full graph transformation
+ */
+export function getTechnicalNodeIds(nodes: AstrolabeNode[]): Set<string> {
+  const technicalIds = new Set<string>()
+  for (const node of nodes) {
+    if (isTechnicalNode(node)) {
+      technicalIds.add(node.id)
+    }
+  }
+  return technicalIds
+}

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -18,6 +18,10 @@ export type NodeKind =
   | 'axiom'
   | 'conjecture'
   | 'example'
+  | 'structure'
+  | 'class'
+  | 'instance'
+  | 'inductive'
   | 'custom'  // Virtual node
 
 export type NodeStatus =


### PR DESCRIPTION
Implements filtering of "technical" nodes (instances, Decidable, coercions) with through-link creation to preserve dependency chains.

Features:
- Filter toggle (funnel icon) hides implementation details
- Through-links (dashed edges) connect nodes that were linked via instances
- Auto-hide orphaned nodes that become disconnected after filtering
- UI shows hidden count with tooltip breakdown (N technical, M orphaned)

Technical nodes detected:
- instance/class kind
- Names starting with 'inst' (instDecidable, instRepr, etc.)
- Coercion patterns (_of_, _to_)
- Decidable instances
- Auto-generated names (underscore prefix, numeric suffix)

New files:
- src/lib/graphProcessing.ts - Core filtering logic
- src/lib/__tests__/graphProcessing.test.ts - 45 unit tests
- src/lib/__tests__/graphProcessing.patterns.test.ts - 14 pattern tests