### PR TITLE
fix: remove externalBin requirement for dev mode

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,9 +35,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "externalBin": [
-      "binaries/astrolabe-server"
-    ]
+    "externalBin": []
   },
   "plugins": {
     "deep-link": {


### PR DESCRIPTION
## Summary

- Removes the externalBin bundle requirement from tauri.conf.json for dev mode
- Allows  to work without pre-built backend binary
- Developers can now run the backend separately with 

## Test plan

- [ ] Run  and verify Tauri starts without errors
- [ ] Run  in a separate terminal
- [ ] Verify the full dev workflow works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)